### PR TITLE
Add new otel.mbeans() signature for multiple ObjectNames

### DIFF
--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -102,7 +102,7 @@ mutually exclusive with `otel.jmx.groovy.script`. The currently supported target
    instances (available via `otel.instrument()`) as described below.  It is intended to be used in cases
    where your given `objectNameStr` can return a multiple element `List<GroovyMBean>`.
 - `otel.mbeans(List<String> objectNameStrs)`
-   - This method is equavalant to the above method except, it adds support for multiple ObjectNames. This support is meant for when there are multiple mbeans that relate to the same metric and can be seperated using labels in `otel.instrument()`.
+   - This method is equivalent to the above method except, it adds support for multiple ObjectNames. This support is meant for when there are multiple mbeans that relate to the same metric and can be seperated using labels in `otel.instrument()`.
 
 - `otel.instrument(MBeanHelper mBeanHelper, String instrumentName, String description, String unit, Map<String, Closure> labelFuncs, String attribute, Closure instrument)`
    - This method provides the ability to easily create and automatically update instrument instances from an

--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -101,6 +101,8 @@ mutually exclusive with `otel.jmx.groovy.script`. The currently supported target
    but returns an `MBeanHelper` instance representing all matching MBeans for usage by subsequent `InstrumentHelper`
    instances (available via `otel.instrument()`) as described below.  It is intended to be used in cases
    where your given `objectNameStr` can return a multiple element `List<GroovyMBean>`.
+- `otel.mbeans(List<String> objectNameStrs)`
+   - This method is equavalant to the above method except, it adds support for multiple ObjectNames. This support is meant for when there are multiple mbeans that relate to the same metric and can be seperated using labels in `otel.instrument()`.
 
 - `otel.instrument(MBeanHelper mBeanHelper, String instrumentName, String description, String unit, Map<String, Closure> labelFuncs, String attribute, Closure instrument)`
    - This method provides the ability to easily create and automatically update instrument instances from an

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelper.groovy
@@ -43,19 +43,19 @@ class MBeanHelper {
 
     private final JmxClient jmxClient
     private final boolean isSingle
-    private List<String> objectNames
+    private final List<String> objectNames
 
     private List<GroovyMBean> mbeans
 
     MBeanHelper(JmxClient jmxClient, String objectName, boolean isSingle) {
         this.jmxClient = jmxClient
-        this.objectNames = [objectName]
+        this.objectNames = Collections.unmodifiableList([objectName])
         this.isSingle = isSingle
     }
 
     MBeanHelper(JmxClient jmxClient, List<String> objectNames) {
         this.jmxClient = jmxClient
-        this.objectNames = objectNames
+        this.objectNames = Collections.unmodifiableList(objectNames)
         this.isSingle = false
     }
 
@@ -72,12 +72,11 @@ class MBeanHelper {
     void fetch() {
         this.mbeans = []
         for(objectName in objectNames){
-            println objectName
             def tmpMbeans = queryJmx(jmxClient, objectName)
-            this.mbeans.addAll(tmpMbeans)
             if (tmpMbeans.size() == 0) {
                 logger.warning("Failed to fetch MBean ${objectName}.")
             } else {
+                this.mbeans.addAll(tmpMbeans)
                 logger.fine("Fetched ${tmpMbeans.size()} MBeans - ${tmpMbeans}")
             }
         }

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelper.groovy
@@ -43,14 +43,13 @@ class MBeanHelper {
 
     private final JmxClient jmxClient
     private final boolean isSingle
-    private final String objectName
+    private List<String> objectNames
 
     private List<GroovyMBean> mbeans
 
     MBeanHelper(JmxClient jmxClient, String objectName, boolean isSingle) {
         this.jmxClient = jmxClient
-        List<String> objectNames = [objectName]
-        this.objectNames = objectNames
+        this.objectNames = [objectName]
         this.isSingle = isSingle
     }
 
@@ -71,13 +70,16 @@ class MBeanHelper {
     }
 
     void fetch() {
+        this.mbeans = []
         for(objectName in objectNames){
-            mbeans = mbeans.add(queryJmx(jmxClient, objectName))
-        }
-        if (mbeans.size() == 0) {
-            logger.warning("Failed to fetch MBean ${objectName}.")
-        } else {
-            logger.fine("Fetched ${mbeans.size()} MBeans - ${mbeans}")
+            println objectName
+            def tmpMbeans = queryJmx(jmxClient, objectName)
+            this.mbeans.addAll(tmpMbeans)
+            if (tmpMbeans.size() == 0) {
+                logger.warning("Failed to fetch MBean ${objectName}.")
+            } else {
+                logger.fine("Fetched ${tmpMbeans.size()} MBeans - ${tmpMbeans}")
+            }
         }
     }
 

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelper.groovy
@@ -49,8 +49,15 @@ class MBeanHelper {
 
     MBeanHelper(JmxClient jmxClient, String objectName, boolean isSingle) {
         this.jmxClient = jmxClient
-        this.objectName = objectName
+        List<String> objectNames = [objectName]
+        this.objectNames = objectNames
         this.isSingle = isSingle
+    }
+
+    MBeanHelper(JmxClient jmxClient, List<String> objectNames) {
+        this.jmxClient = jmxClient
+        this.objectNames = objectNames
+        this.isSingle = false
     }
 
     @PackageScope static List<GroovyMBean> queryJmx(JmxClient jmxClient, String objNameStr) {
@@ -64,7 +71,9 @@ class MBeanHelper {
     }
 
     void fetch() {
-        mbeans = queryJmx(jmxClient, objectName)
+        for(objectName in objectNames){
+            mbeans = mbeans.add(queryJmx(jmxClient, objectName))
+        }
         if (mbeans.size() == 0) {
             logger.warning("Failed to fetch MBean ${objectName}.")
         } else {

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
@@ -74,6 +74,18 @@ class OtelHelper {
     }
 
     /**
+     * Returns a fetched, potentially multi-{@link GroovyMBean} {@link MBeanHelper} for a given object name String.
+     * @param objNameStr - the {@link String} representation of an object name or pattern, to be
+     * used as the argument to the basic {@link javax.management.ObjectName} constructor for the JmxClient query.
+     * @return a {@link MBeanHelper} that operates over all resulting {@link GroovyMBean} instances.
+     */
+    MBeanHelper mbeans(List<String> objNameStrs) {
+        def mbeanHelper = new MBeanHelper(jmxClient, objNameStrs)
+        mbeanHelper.fetch()
+        return mbeanHelper
+    }
+
+    /**
      * Returns a fetched, single {@link GroovyMBean} {@link MBeanHelper} for a given object name String.
      * @param objNameStr - the {@link String} representation of an object name or pattern, to be
      * used as the argument to the basic {@link javax.management.ObjectName} constructor for the JmxClient query.

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelperTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelperTest.groovy
@@ -61,7 +61,7 @@ class MBeanHelperTest extends Specification {
     }
 
     @Unroll
-    def"represents #quantity MBean(s)"() {
+    def "represents #quantity MBean(s)"() {
         setup:
         def thingName = "io.opentelemetry.contrib.jmxmetrics:type=${quantity}Thing"
         def things = (0..100).collect { new Thing(it as String) }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelperTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelperTest.groovy
@@ -61,7 +61,7 @@ class MBeanHelperTest extends Specification {
     }
 
     @Unroll
-    def "represents #quantity MBean(s)"() {
+    def"represents #quantity MBean(s)"() {
         setup:
         def thingName = "io.opentelemetry.contrib.jmxmetrics:type=${quantity}Thing"
         def things = (0..100).collect { new Thing(it as String) }


### PR DESCRIPTION
**Description:**

 Added additional signature for `otel.mbeans` to handle multiple ObjectName Strings. this for when there are multiple means that relate to each other but aren't necessarily under the same ObjectName. Then, when it is passed to `otel.instrument`, the mbeans can be differentiated through the labels.

**Testing:**

Added a test that registers multiple mbeans and then passes two different `ObjectNames` and checks whether or not they were pulled.

**Documentation:**

 Added documentation of the new signature
